### PR TITLE
Make it work with Godot 4.2.2

### DIFF
--- a/addons/Holepunch/holepunch_node.gd
+++ b/addons/Holepunch/holepunch_node.gd
@@ -58,7 +58,6 @@ func _process(delta):
 	if peer_udp.get_available_packet_count() > 0:
 		var array_bytes = peer_udp.get_packet()
 		var packet_string = array_bytes.get_string_from_ascii()
-		print("Peer packet received: ", packet_string)
 		if not recieved_peer_greet:
 			if packet_string.begins_with(PEER_GREET):
 				var m = packet_string.split(":")
@@ -77,7 +76,6 @@ func _process(delta):
 	if server_udp.get_available_packet_count() > 0:
 		var array_bytes = server_udp.get_packet()
 		var packet_string = array_bytes.get_string_from_ascii()
-		print("Server packet received: ", packet_string)
 		if packet_string.begins_with(SERVER_OK):
 			var m = packet_string.split(":")
 			own_port = int( m[1] )
@@ -211,7 +209,6 @@ func checkout():
 #Call this function when you want to start the holepunch process
 func start_traversal(id, is_player_host, player_name):
 	if server_udp.is_bound():
-		print("Closing already bound server")
 		server_udp.close()
 
 	var err = server_udp.bind(rendevouz_port, "*")

--- a/addons/Holepunch/holepunch_node.gd
+++ b/addons/Holepunch/holepunch_node.gd
@@ -58,6 +58,7 @@ func _process(delta):
 	if peer_udp.get_available_packet_count() > 0:
 		var array_bytes = peer_udp.get_packet()
 		var packet_string = array_bytes.get_string_from_ascii()
+		print("Peer packet received: ", packet_string)
 		if not recieved_peer_greet:
 			if packet_string.begins_with(PEER_GREET):
 				var m = packet_string.split(":")
@@ -76,6 +77,7 @@ func _process(delta):
 	if server_udp.get_available_packet_count() > 0:
 		var array_bytes = server_udp.get_packet()
 		var packet_string = array_bytes.get_string_from_ascii()
+		print("Server packet received: ", packet_string)
 		if packet_string.begins_with(SERVER_OK):
 			var m = packet_string.split(":")
 			own_port = int( m[1] )
@@ -88,10 +90,13 @@ func _process(delta):
 		if not recieved_peer_info:
 			if packet_string.begins_with(SERVER_INFO):
 				server_udp.close()
-				packet_string = packet_string.right(6)
 				if packet_string.length() > 2:
 					var m = packet_string.split(":")
-					peer[m[0]] = {"port":m[2], "address":m[1]}
+					var peer_name = m[1]
+					var peer_address = m[2]
+					var peer_port = m[3]
+					peer[peer_name] = {"port":peer_port, "address":peer_address}
+					print(peer_name, " ", peer[peer_name])
 					recieved_peer_info = true
 					start_peer_contact()
 
@@ -100,7 +105,7 @@ func _handle_greet_message(peer_name, peer_port, my_port):
 	if own_port != my_port:
 		own_port = my_port
 		peer_udp.close()
-		peer_udp.listen(own_port, "*")
+		peer_udp.bind(own_port, "*")
 	recieved_peer_greet = true
 
 
@@ -113,14 +118,15 @@ func _handle_confirm_message(peer_name, peer_port, my_port, is_host):
 		host_address = peer[peer_name].address
 		host_port = peer[peer_name].port
 	peer_udp.close()
-	peer_udp.listen(own_port, "*")
+	peer_udp.bind(own_port, "*")
 	recieved_peer_confirm = true
 
 
 func _handle_go_message(peer_name):
 	recieved_peer_go = true
-	emit_signal("hole_punched", int(own_port), int(host_port), host_address)
 	peer_udp.close()
+	server_udp.close()
+	emit_signal("hole_punched", int(own_port), int(host_port), host_address)
 	p_timer.stop()
 	set_process(false)
 
@@ -168,6 +174,8 @@ func _ping_peer():
 		gos_sent += 1
 
 		if gos_sent >= response_window: #the other player has confirmed and is probably waiting
+			peer_udp.close()
+			server_udp.close()
 			emit_signal("hole_punched", int(own_port), int(host_port), host_address)
 			p_timer.stop()
 			set_process(false)
@@ -178,7 +186,7 @@ func start_peer_contact():
 	server_udp.close()
 	if peer_udp.is_bound():
 		peer_udp.close()
-	var err = peer_udp.listen(own_port, "*")
+	var err = peer_udp.bind(own_port, "*")
 	if err != OK:
 		print("Error listening on port: " + str(own_port) +" Error: " + str(err))
 	p_timer.start()
@@ -203,6 +211,7 @@ func checkout():
 #Call this function when you want to start the holepunch process
 func start_traversal(id, is_player_host, player_name):
 	if server_udp.is_bound():
+		print("Closing already bound server")
 		server_udp.close()
 
 	var err = server_udp.bind(rendevouz_port, "*")


### PR DESCRIPTION
Hi there! We've been adapting the script to make it work properly on Godot 4.2.2. Here are the changes we had to introduce to make it work for us.

- Fixed the `SERVER_INFO` packet parsing (it was just picking the port and ignoring address and peer name).
- Changed remaining calls from `listen` (not present anymore in Godot 4.2.2) to `bind`.
- Closed sockets **before** signaling `hole_punched`, so if a new socket starts immediately afterwards, there won't be any problems with the port being in use.
- Made sure that both `server_udp` and `peer_udp` are closed before emitting `hole_punched`.

Hope this is useful!
